### PR TITLE
fix: move camelot dependency to own group

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,13 +62,14 @@ dev =
     nbsphinx
     networkx
     xdoctest
-    camelot-py[base] >= 0.11.0
     tox
     unfccc_di_api >= 3.0.1
     openscm-units
     pycountry
     lxml
     tqdm
+ipcc =
+    camelot-py[base] >= 0.11.0
 
 [options.package_data]
 * =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

camelot seems to be broken
