### PR TITLE
fix: update minimum dependency versions for python 3.13

### DIFF
--- a/changelog_unreleased/167.improvement.rst
+++ b/changelog_unreleased/167.improvement.rst
@@ -1,1 +1,1 @@
-* Extend documentation for deployment process
+* Improved the documentation for the deployment process

--- a/changelog_unreleased/169.improvement.rst
+++ b/changelog_unreleased/169.improvement.rst
@@ -1,1 +1,1 @@
-Adding category M.3.C.45.AG
+* Added the category M.3.C.45.AG to the IPCC2006_PRIMAP categorisation

--- a/changelog_unreleased/175.trivial.rst
+++ b/changelog_unreleased/175.trivial.rst
@@ -1,0 +1,1 @@
+* Fixed minimum dependencies for Python 3.13.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
 install_requires =
     networkx>=3
     pandas>=2
-    pandas>=2.2.2;python_version>="3.13"
+    pandas>=2.2.3;python_version>="3.13"
     strictyaml>=1.6
     natsort>=8
     ruamel.yaml>=0.17.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     immutables>=0.21;python_version>="3.13"
     black>=22.1
     numpy>=1.26
-    numpy>=2.1;python_version>="3.13"
+    numpy>=2.1.3;python_version>="3.13"
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     ruamel.yaml>=0.17.2
     pyparsing>=3.1
     immutables>=0.20
+    immutables>=0.21;python_version>="3.13"
     black>=22.1
     numpy>=1.26
     numpy>=2.1;python_version>="3.13"


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

For python 3.13, we need a newer version of `immutables`, `numpy`, and `pandas`. This should fix the CI.
