### PR TITLE
Remove auxiliary dimension after filtering

### DIFF
--- a/changelog_unreleased/188.improvement.rst
+++ b/changelog_unreleased/188.improvement.rst
@@ -1,0 +1,1 @@
+* Adjusts removal or preservation of auxiliary dimensions when filtering a conversion object.

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -457,6 +457,17 @@ class ConversionRule:
             csv_original_text=self.csv_original_text,
         )
 
+    def remove_aux_cats(self):
+        """Return the ConversionRule"""
+        return ConversionRule(
+            factors_categories_a=self.factors_categories_a,
+            factors_categories_b=self.factors_categories_b,
+            auxiliary_categories={},
+            comment=self.comment,
+            csv_line_number=self.csv_line_number,
+            csv_original_text=self.csv_original_text,
+        )
+
     @staticmethod
     def _format_factor_category_human_readable(
         factor: int, category: "Category"
@@ -962,6 +973,9 @@ class Conversion(ConversionBase):
             if not allowed_indices or any(
                 aux_categorisation[criteria] in allowed_indices for criteria in values
             ):
+                # remove the aux dimension from the rule
+                # TODO write this function
+                rule = rule.remove_aux_cats()
                 rules_filtered.append(rule)
 
         if not rules_filtered:
@@ -970,11 +984,15 @@ class Conversion(ConversionBase):
                 f"with values {values}."
             )
 
+        new_auxiliary_categorizations = [
+            i for i in self.auxiliary_categorizations if i.name != aux_dim
+        ] or None
+
         return Conversion(
             categorization_a=self.categorization_a,
             categorization_b=self.categorization_b,
             rules=rules_filtered,
-            auxiliary_categorizations=self.auxiliary_categorizations,
+            auxiliary_categorizations=new_auxiliary_categorizations,
             comment=(self.comment or "") + f" (filtered for {aux_dim} in {values})",
             references=self.references,
             institution=self.institution,

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -957,7 +957,7 @@ class Conversion(ConversionBase):
         Notes
         -----
         - If no rules match the filter criteria, the method will return an error.
-        - If only one value is provided, the method will remove the specified auxiliary,
+        - If only one value is provided, the method will remove the specified auxiliary categorisations,
           otherwise it will keep the auxiliary categorisations as they are.
         """
 
@@ -979,7 +979,6 @@ class Conversion(ConversionBase):
             if not allowed_indices or any(
                 aux_categorisation[criteria] in allowed_indices for criteria in values
             ):
-                # remove the aux dimension from the rule
                 if len(values) == 1:
                     rule = rule.remove_aux_cats(
                         aux_categorisation_to_remove=aux_categorisation

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -457,12 +457,16 @@ class ConversionRule:
             csv_original_text=self.csv_original_text,
         )
 
-    def remove_aux_cats(self):
-        """Return the ConversionRule"""
+    def remove_aux_cats(
+        self, aux_categorisation_to_remove: dict["Categorization", set["Category"]]
+    ) -> "ConversionRule":
+        """Return the ConversionRule without the specified auxiliary categories"""
+        auxiliary_categories_new = self.auxiliary_categories.copy()
+        del auxiliary_categories_new[aux_categorisation_to_remove]
         return ConversionRule(
             factors_categories_a=self.factors_categories_a,
             factors_categories_b=self.factors_categories_b,
-            auxiliary_categories={},
+            auxiliary_categories=auxiliary_categories_new,
             comment=self.comment,
             csv_line_number=self.csv_line_number,
             csv_original_text=self.csv_original_text,
@@ -974,8 +978,9 @@ class Conversion(ConversionBase):
                 aux_categorisation[criteria] in allowed_indices for criteria in values
             ):
                 # remove the aux dimension from the rule
-                # TODO write this function
-                rule = rule.remove_aux_cats()
+                rule = rule.remove_aux_cats(
+                    aux_categorisation_to_remove=aux_categorisation
+                )
                 rules_filtered.append(rule)
 
         if not rules_filtered:

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -957,6 +957,8 @@ class Conversion(ConversionBase):
         Notes
         -----
         - If no rules match the filter criteria, the method will return an error.
+        - If only one value is provided, the method will remove the specified auxiliary,
+          otherwise it will keep the auxiliary categorisations as they are.
         """
 
         if aux_dim not in self.auxiliary_categorizations_names:
@@ -978,9 +980,10 @@ class Conversion(ConversionBase):
                 aux_categorisation[criteria] in allowed_indices for criteria in values
             ):
                 # remove the aux dimension from the rule
-                rule = rule.remove_aux_cats(
-                    aux_categorisation_to_remove=aux_categorisation
-                )
+                if len(values) == 1:
+                    rule = rule.remove_aux_cats(
+                        aux_categorisation_to_remove=aux_categorisation
+                    )
                 rules_filtered.append(rule)
 
         if not rules_filtered:
@@ -989,16 +992,19 @@ class Conversion(ConversionBase):
                 f"with values {values}."
             )
 
-        new_auxiliary_categorizations = [
-            i for i in self.auxiliary_categorizations if i.name != aux_dim
-        ] or None
+        if len(values) == 1:
+            new_auxiliary_categorizations = [
+                i for i in self.auxiliary_categorizations if i.name != aux_dim
+            ] or None
+        else:
+            new_auxiliary_categorizations = self.auxiliary_categorizations
 
         return Conversion(
             categorization_a=self.categorization_a,
             categorization_b=self.categorization_b,
             rules=rules_filtered,
             auxiliary_categorizations=new_auxiliary_categorizations,
-            comment=(self.comment or "") + f" (filtered for {aux_dim} in {values})",
+            comment=(self.comment or "") + f" (filtered for {values} in {aux_dim})",
             references=self.references,
             institution=self.institution,
             last_update=self.last_update,

--- a/climate_categories/data/conversion.FAO.IPCC2006_PRIMAP.csv
+++ b/climate_categories/data/conversion.FAO.IPCC2006_PRIMAP.csv
@@ -3,8 +3,8 @@
 FAO,gas,IPCC2006_PRIMAP,comment
 4,CO2,3.B.1,Carbon stock change in forests
 4.B,CO2,M.NFC,Net Forest conversion
-5.A,CO2 N2O,3.B.3.a,Drained grassland
-5.B,CO2 N2O,3.B.2.a,Drained cropland
+5.A,CO2 N2O,3.B.3,Drained grassland
+5.B,CO2 N2O,3.B.2,Drained cropland
 6.A,CO2 N2O CH4,3.C.1.a, FAO 6.A forest fires to IPCC 3.C.1.a Biomass burning in forest lands
 6.B,CO2 N2O CH4, 3.C.1.c, FAO 6.B savanna fires to IPCC 3.C.1.c Biomass burning in grasslands
 6.C,CO2, 3.C.1.b, FAO 6.C Fires in organic soils to IPCC 3.C.1.b Biomass Burning In Croplands

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -582,6 +582,37 @@ def test_filter_ipcc1996_to_ipcc2006_by_gas():
     assert len(conv_CO2.rules) == n_all_rules - 1
 
 
+def test_filter_removes_aux_dim_from_resulting_conv():
+    categorisation_a = climate_categories.from_yaml(
+        get_test_data_filepath("simple_categorisation_a.yaml")
+    )
+
+    categorisation_b = climate_categories.from_yaml(
+        get_test_data_filepath("simple_categorisation_b.yaml")
+    )
+
+    cats = {
+        "A": categorisation_a,
+        "B": categorisation_b,
+        "gas": climate_categories.cats["gas"],
+    }
+
+    conv = climate_categories.Conversion.from_csv(
+        get_test_data_filepath("simple_conversion_by_gas.csv"), cats=cats
+    )
+
+    conv_N2O = conv.filter(aux_dim="gas", values=["N2O"])
+
+    assert len(conv_N2O.rules) == 1
+    assert conv_N2O.rules[0].csv_original_text == "2+3,CH4 N2O,2"
+
+    # make sure auxiliary dimension was removed
+    assert not conv_N2O.auxiliary_categorizations
+    assert not conv_N2O.auxiliary_categorizations
+
+    assert all(not i.auxiliary_categories for i in conv_N2O.rules)
+
+
 def test_filter_fao_to_ipcc2006primap_by_gas():
     conv = climate_categories.FAO.conversion_to(climate_categories.IPCC2006_PRIMAP)
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

Refactored the filtering logic to remove auxiliary dimensions after applying the filter function. The filtered conversion correctly retains only the specified rules, but it still includes auxiliary dimension information. When passed to the convert function, it attempts to find these extra dimensions in the dataset’s coordinates, which fails because gases are stored as data variables, not coordinates. This change ensures that auxiliary dimensions are removed after filtering.

### To be discussed
With this approach, we remove the option of filtering for more than one gas. We had planned to simply call the function several times for this case. The returned conversion no longer contains any information about additional dimensions, so we can't filter for them either. However, I can't think of a use case for this at the moment. The typical call would look something like this:

```python
# convert for each entity
da_dict = {}
for var in ["CO2", "N2O"]:
    conv_for_gas = conv.filter(aux_dim="gas", values=[var])
	# apply convert function on data array
    da_dict[var] = ds[var].pr.convert(
        dim="category (FAO)",
        conversion=conv_for_gas,
    )
result = xr.Dataset(da_dict)

```