### PR TITLE
Convert YAML to Python specs in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,16 +104,13 @@ climate_categories/data/%.yaml: data_generation/%.py data_generation/utils.py
 	uv run --group data-generation python $<
 
 climate_categories/data/%.py: climate_categories/data/%.yaml data_generation/convert_yaml_to_python.py
-	uv run python data_generation/convert_yaml_to_python.py $< $@
+	uv run python data_generation/convert_yaml_to_python.py $<
 
 # Unlike `cache`, this ignores timestamps and picks up new YAML files by itself, so it
 # cannot silently skip anything. A fresh git checkout gives every file the same mtime,
 # which make reads as "up to date", so CI and the release have to use this target.
 recache:  ## Regenerate all Python specs from the YAML files, unconditionally
-	@for yaml in climate_categories/data/*.yaml; do \
-		echo "$$yaml"; \
-		uv run python data_generation/convert_yaml_to_python.py $$yaml $${yaml%.yaml}.py; \
-	done
+	uv run python data_generation/convert_yaml_to_python.py climate_categories/data/*.yaml
 
 .PHONY: README.rst
 README.rst:  ## Update the citation information from zenodo

--- a/changelog_unreleased/faster_recache.rst
+++ b/changelog_unreleased/faster_recache.rst
@@ -1,0 +1,2 @@
+* Sped up regenerating the cached Python specs by converting the YAML files in
+  parallel, roughly halving the time the release and CI spend on it.

--- a/data_generation/convert_yaml_to_python.py
+++ b/data_generation/convert_yaml_to_python.py
@@ -1,14 +1,58 @@
-"""Convert a categorization stored in a StrictYaml file to a Python
-file for faster loading."""
+"""Convert categorizations stored in StrictYaml files to Python files for faster
+loading.
 
+Each categorization is written next to its YAML file, with the extension changed to
+``.py``. Parsing StrictYaml is slow -- which is why the Python files exist in the
+first place -- so the files are converted in parallel.
+"""
+
+import argparse
+import concurrent.futures
+import pathlib
 import sys
 
 import climate_categories
 
 
-def main():
-    cat = climate_categories.from_yaml(sys.argv[1])
-    cat.to_python(sys.argv[2])
+def convert(yaml_path: pathlib.Path) -> pathlib.Path:
+    """Convert one YAML file to the Python file next to it."""
+    python_path = yaml_path.with_suffix(".py")
+    climate_categories.from_yaml(yaml_path).to_python(python_path)
+    return python_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "yaml_files",
+        metavar="FILE.yaml",
+        nargs="+",
+        type=pathlib.Path,
+        help="categorization to convert, written to FILE.py",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=None,
+        help="number of files to convert in parallel (default: one per CPU)",
+    )
+    args = parser.parse_args()
+
+    errors = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=args.jobs) as executor:
+        futures = {executor.submit(convert, f): f for f in args.yaml_files}
+        for future in concurrent.futures.as_completed(futures):
+            yaml_path = futures[future]
+            try:
+                print(future.result(), flush=True)
+            except Exception as err:  # noqa: BLE001
+                errors.append((yaml_path, err))
+
+    for yaml_path, err in errors:
+        print(f"error: converting {yaml_path} failed: {err}", file=sys.stderr)
+    if errors:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #254: `make recache` took ~160 s, which slows down both the release and the new `caches-up-to-date` CI job.

### Where the time goes

Profiled over all 19 files:

| stage | total | share |
| --- | --- | --- |
| `from_yaml` (strictyaml parsing) | 132.6 s | 88% |
| `to_python` (build + black) | 17.4 s | 12% |
| per-file process startup | ~11 s | overhead |

So the cost is inherent — it is exactly the strictyaml parsing that the Python specs exist to avoid. `CRFDI_class.yaml` alone is 25 s; the four `CRF2013*` files are another 64 s.

### What this changes

The files are independent, so they are now converted in parallel. `convert_yaml_to_python.py` takes one or more YAML files and derives each output path from its input, which also means `make recache` is a single process rather than one `uv run` per file — each of those paid 0.6 s to import `climate_categories`, which eagerly loads all 19 cached specs. Converting one file used to load all nineteen caches first, nineteen times over.

| | wall time |
| --- | --- |
| before | ~160 s |
| after, 4 cores | ~60 s |
| after, 16 cores | ~50 s |

The floor is the single slowest file (~28 s), so more than 4 cores buys little. On GitHub's 4-core runners expect roughly 160 s → 60 s.

Errors are collected per file and reported together, with a non-zero exit, rather than aborting on the first one.

### Verified

`make recache` output is byte-identical to the committed specs; the single-file path used by `make cache` still works and also produces identical output; 123 tests pass; `make lint` clean. Error paths checked for a missing file, alone and mixed with a good one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qaydbV44wWxQZnuRzJXMB