### PR TITLE
Write the cached Python spec from the generation scripts

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,9 +49,17 @@ data generation scripts (see ``data_generation/IPCC2006.py`` for an example how 
 do that efficiently with caching).
 
 Because all Categorizations are read in when importing ``climate_categories`` and
-parsing StrictYaml files is not very efficient, the categories should be also stored
-as cached Python files using the ``to_python`` instance method.
-Run `make cache` to generate these from the YAML files.
+parsing StrictYaml files is not very efficient, the categories are also stored as
+cached Python files. Generation scripts write both at once by finishing with
+``utils.write_categorization(categorization, OUTPATH)``, which writes the YAML file,
+reads it back to validate it, and writes the Python file next to it. Use that instead
+of calling ``to_yaml`` yourself, so the two files cannot get out of step.
+
+For categorizations written by hand there is no generation script, so run
+``make recache`` to build the Python files from the YAML files. You also need it when
+the generated format itself changes, for example after a formatter update, because
+then every Python file has to be rebuilt without re-running the generation scripts.
+CI checks that the two are in sync.
 
 New conversions
 ~~~~~~~~~~~~~~~

--- a/changelog_unreleased/generate_python_specs_directly.rst
+++ b/changelog_unreleased/generate_python_specs_directly.rst
@@ -1,0 +1,2 @@
+* The data generation scripts now write the cached Python file alongside the YAML file,
+  so the two cannot get out of step after regenerating a categorization.

--- a/data_generation/BURDI.py
+++ b/data_generation/BURDI.py
@@ -5,6 +5,7 @@ import pathlib
 import natsort
 import treelib
 from unfccc_di_api import UNFCCCApiReader
+from utils import write_categorization
 
 import climate_categories
 
@@ -152,9 +153,7 @@ def main():
 
     CRFDI = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRFDI.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRFDI, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/BURDI_class.py
+++ b/data_generation/BURDI_class.py
@@ -5,6 +5,7 @@ import pathlib
 
 import numpy as np
 import unfccc_di_api
+from utils import write_categorization
 
 import climate_categories
 
@@ -81,9 +82,7 @@ def main():
     )
     BURDI_class.total_sum = False  # unfortunately, not generally true anymore
 
-    BURDI_class.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(BURDI_class, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRF1999.py
+++ b/data_generation/CRF1999.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CRF1999.yaml")
@@ -466,9 +468,7 @@ def main():
 
     CRF1999 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRF1999.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRF1999, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRF2013.py
+++ b/data_generation/CRF2013.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CRF2013.yaml")
@@ -1630,9 +1632,7 @@ def main():
 
     CRF2013 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRF2013.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRF2013, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRF2013_2021.py
+++ b/data_generation/CRF2013_2021.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CRF2013_2021.yaml")
@@ -779,9 +781,7 @@ def main():
 
     CRF2013_2021 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRF2013_2021.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRF2013_2021, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRF2013_2022.py
+++ b/data_generation/CRF2013_2022.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CRF2013_2022.yaml")
@@ -800,9 +802,7 @@ def main():
 
     CRF2013_2022 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRF2013_2022.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRF2013_2022, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRF2013_2023.py
+++ b/data_generation/CRF2013_2023.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CRF2013_2023.yaml")
@@ -809,9 +811,7 @@ def main():
 
     CRF2013_2023 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRF2013_2023.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRF2013_2023, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRFDI.py
+++ b/data_generation/CRFDI.py
@@ -5,6 +5,7 @@ import pathlib
 import natsort
 import treelib
 from unfccc_di_api import UNFCCCApiReader
+from utils import write_categorization
 
 import climate_categories
 
@@ -144,9 +145,7 @@ def main():
 
     CRFDI = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    CRFDI.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRFDI, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CRFDI_class.py
+++ b/data_generation/CRFDI_class.py
@@ -6,6 +6,7 @@ import pathlib
 import numpy as np
 import treelib
 import unfccc_di_api
+from utils import write_categorization
 
 import climate_categories
 
@@ -137,9 +138,7 @@ def main():
     )
     CRFDI_class.total_sum = False  # unfortunately, not generally true anymore
 
-    CRFDI_class.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CRFDI_class, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/CT.py
+++ b/data_generation/CT.py
@@ -2,6 +2,8 @@
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/CT.yaml")
@@ -151,9 +153,7 @@ def main():
 
     CT = climate_categories.HierarchicalCategorization.from_spec(spec.copy())
 
-    CT.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(CT, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/FAO.py
+++ b/data_generation/FAO.py
@@ -3,6 +3,8 @@ directory."""
 
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories as cc
 
 OUTPATH = pathlib.Path("./climate_categories/data/FAO.yaml")
@@ -713,8 +715,7 @@ def main():
     spec["categories"] = categories
     fao_cats = cc.HierarchicalCategorization.from_spec(spec.copy())
 
-    fao_cats.to_yaml(OUTPATH)
-    cc.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(fao_cats, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/IPCC1996.py
+++ b/data_generation/IPCC1996.py
@@ -4,7 +4,7 @@ import pathlib
 import typing
 
 import camelot
-from utils import download_cached, title_case
+from utils import download_cached, title_case, write_categorization
 
 import climate_categories
 
@@ -359,9 +359,7 @@ def main():
 
     IPCC1996 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    IPCC1996.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(IPCC1996, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/IPCC2006.py
+++ b/data_generation/IPCC2006.py
@@ -5,7 +5,7 @@ import pathlib
 import typing
 
 import camelot
-from utils import download_cached, title_case
+from utils import download_cached, title_case, write_categorization
 
 import climate_categories
 
@@ -269,9 +269,7 @@ def main():
 
     IPCC2006 = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    IPCC2006.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(IPCC2006, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/IPCC2006_PRIMAP.py
+++ b/data_generation/IPCC2006_PRIMAP.py
@@ -4,6 +4,8 @@ directory."""
 import datetime
 import pathlib
 
+from utils import write_categorization
+
 import climate_categories
 
 OUTPATH = pathlib.Path("./climate_categories/data/IPCC2006_PRIMAP.yaml")
@@ -237,9 +239,7 @@ def main():
     ipcc2006_primap.institution = "Climate Resource"
     ipcc2006_primap.canonical_top_level_category = ipcc2006_primap["0"]
 
-    ipcc2006_primap.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(ipcc2006_primap, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/ISO3.py
+++ b/data_generation/ISO3.py
@@ -3,6 +3,7 @@
 import pathlib
 
 import requests
+from utils import write_categorization
 
 import climate_categories
 
@@ -792,6 +793,4 @@ def load_countries() -> dict[str, str | dict[str, str] | list[str] | list[list[s
 if __name__ == "__main__":
     ISO3 = main()
 
-    ISO3.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(ISO3, OUTPATH)

--- a/data_generation/ISO3_GCAM.py
+++ b/data_generation/ISO3_GCAM.py
@@ -7,6 +7,7 @@ import pathlib
 import pandas as pd
 import pycountry
 import tqdm
+from utils import write_categorization
 
 import climate_categories
 
@@ -88,9 +89,7 @@ def main():
     )
     iso3_gcam.institution = "Joint Global Change Research Institute "
 
-    iso3_gcam.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(iso3_gcam, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/RCMIP.py
+++ b/data_generation/RCMIP.py
@@ -3,7 +3,7 @@
 import pathlib
 
 import pandas as pd
-from utils import download_cached
+from utils import download_cached, write_categorization
 
 import climate_categories
 
@@ -177,9 +177,7 @@ def main():
 
     RCMIP = climate_categories.HierarchicalCategorization.from_spec(spec)
 
-    RCMIP.to_yaml(OUTPATH)
-
-    climate_categories.HierarchicalCategorization.from_yaml(OUTPATH)
+    write_categorization(RCMIP, OUTPATH)
 
 
 if __name__ == "__main__":

--- a/data_generation/gas.py
+++ b/data_generation/gas.py
@@ -5,6 +5,7 @@ import pathlib
 import openscm_units
 import openscm_units.data
 import openscm_units.data.mixtures
+from utils import write_categorization
 
 import climate_categories
 
@@ -37,7 +38,7 @@ def main():
     }
 
     gas = climate_categories.HierarchicalCategorization.from_spec(spec)
-    gas.to_yaml(OUTPATH)
+    write_categorization(gas, OUTPATH)
 
 
 def openscm_mixtures():

--- a/data_generation/utils.py
+++ b/data_generation/utils.py
@@ -3,6 +3,21 @@ import shutil
 
 import requests
 
+import climate_categories
+
+
+def write_categorization(
+    categorization: "climate_categories.Categorization", yaml_path: pathlib.Path
+) -> None:
+    """Write a categorization as YAML and as the cached Python spec next to it.
+
+    The Python spec is generated from the YAML we just wrote, so it goes through
+    exactly the same code path as ``make recache`` and the two cannot disagree.
+    Reading the YAML back in also validates it.
+    """
+    categorization.to_yaml(yaml_path)
+    climate_categories.from_yaml(yaml_path).to_python(yaml_path.with_suffix(".py"))
+
 
 def download_cached(url: str, fpath: pathlib.Path):
     if not fpath.exists():


### PR DESCRIPTION
The generation scripts already built a categorization, wrote it as YAML, and read it back to validate it — then threw the parsed result away, leaving the Python spec to a separate `make cache` run that was easy to forget.

They now finish with a shared helper:

```python
write_categorization(CT, OUTPATH)
```

which writes the YAML, reads it back, and writes the Python spec next to it. Two consequences worth noting:

- The spec is generated **from the re-read YAML**, i.e. the exact code path `make recache` uses, so the two can never produce different bytes. Verified: writing from the in-memory object happens to give identical output today, but going through the YAML makes that guaranteed rather than incidental.
- The validation read is no longer wasted work — it now produces the spec.

This replaces the `X.to_yaml(OUTPATH)` + discarded `from_yaml(OUTPATH)` pair in all 18 scripts. `gas.py` gains the validation read it was missing.

### What this does not remove

`make recache` and the `caches-up-to-date` CI job both stay, and they remain what actually *guarantees* the two files agree:

- `GCB` is maintained by hand and has no generation script.
- Hand-written YAML is a documented, supported way to add a categorization.
- When the generated format itself changes — a formatter update, say — every spec has to be rebuilt without re-running the network-bound scripts.

So this closes the common drift path (regenerate a categorization, forget the spec) rather than eliminating the error class; the CI guard from #254 is what does that.

### Verified

**14 of the 18 scripts were run end to end**, each confirmed to write both files, with the generated spec byte-identical to what the YAML→Python converter produces from the same YAML:

`CRF1999`, `CRF2013`, `CRF2013_2021`, `CRF2013_2022`, `CRF2013_2023`, `CT`, `FAO`, `IPCC1996`, `IPCC2006`, `IPCC2006_PRIMAP`, `ISO3`, `ISO3_GCAM`, `RCMIP`, `gas`

The remaining four — `BURDI`, `BURDI_class`, `CRFDI`, `CRFDI_class` — query the UNFCCC DI API, which denies access from this machine (`RuntimeError: Access to the UNFCCC API denied`). Their edits are the same two-line replacement as the others. All regenerated data files were reverted; the PR touches no YAML or spec.

Also: 123 tests pass, `make lint` clean, docs build without warnings.

One thing I left alone: the variable in `BURDI.py` is named `CRFDI`, so the call reads `write_categorization(CRFDI, OUTPATH)`. That is the pre-existing name; renaming it felt out of scope here.