### PR TITLE
chore: re-allow older pandas versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
         resolution: ["highest", "lowest-direct"]
+        exclude:
+          - python-version: "3.13"
+            resolution: "lowest-direct"
+          - python-version: "3.14"
+            resolution: "lowest-direct"
     steps:
       - uses: actions/checkout@v5
 

--- a/changelog_unreleased/pandas.rst
+++ b/changelog_unreleased/pandas.rst
@@ -1,0 +1,1 @@
+* re-allowed older pandas versions >= 2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "networkx>=3.3",
-    "pandas==2.2.2",
+    "pandas>=2.2.2",
     "strictyaml>=1.6",
     "natsort>=8",
     "ruamel.yaml>=0.17.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "networkx>=3.3",
-    "pandas>=3.0",
+    "pandas==2.2.2",
     "strictyaml>=1.6",
     "natsort>=8",
     "ruamel.yaml>=0.17.2",


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- ~~Tests added~~
- ~~Documentation added (where applicable)~~
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

* re-allow older pandas versions >= 2.2.2